### PR TITLE
Fix jumpcompress missing label unconditional jump

### DIFF
--- a/examples/jumpcompress/negative_simpleloop.hrm
+++ b/examples/jumpcompress/negative_simpleloop.hrm
@@ -1,0 +1,6 @@
+start:
+emp = inbox
+if nz then
+	outbox
+endif
+jmp start

--- a/examples/jumpcompress/nooptimize_jmp_to_non_associated_label.hrm
+++ b/examples/jumpcompress/nooptimize_jmp_to_non_associated_label.hrm
@@ -1,8 +1,12 @@
 start:
 emp = inbox
-jmp misspelledStart
+jmp a
 # when executed in hrm-interpreter,
 # the `outbox` should not be executed at all.
 outbox
 jmp start
+a:
+jmp b
+b:
+jmp misspelledStart
 misspelledStart:

--- a/examples/jumpcompress/nooptimize_jmp_to_non_associated_label.hrm
+++ b/examples/jumpcompress/nooptimize_jmp_to_non_associated_label.hrm
@@ -1,0 +1,8 @@
+start:
+emp = inbox
+jmp misspelledStart
+# when executed in hrm-interpreter,
+# the `outbox` should not be executed at all.
+outbox
+jmp start
+misspelledStart:

--- a/examples/jumpcompress/simpleloop.hrm
+++ b/examples/jumpcompress/simpleloop.hrm
@@ -1,0 +1,6 @@
+start:
+emp = inbox
+if ez then
+	outbox
+endif
+jmp start

--- a/hrmcompiler/conversion.py
+++ b/hrmcompiler/conversion.py
@@ -171,24 +171,21 @@ def compress_jumps(ast):
                 next_pos = labels_positions[_label]
             except KeyError:
                 jump_going_nowhere = True
-
-            if jump_going_nowhere:
                 # even though a jump, either conditional or unconditional, redirects to a label
                 # that is _not_ associated to any instruction, removing conditional
                 # jumps alters the logic of the program
                 compressed_ast.append(ast_item)
                 continue
 
-            if not jump_going_nowhere:
-                while type(ast[next_pos]) == p.JumpOp and \
-                    not visited[next_pos] and \
-                    not jump_going_nowhere:
-                    visited[next_pos] = True
-                    _label = ast[next_pos].label_name
-                    try:
-                        next_pos = labels_positions[_label]
-                    except KeyError:
-                        jump_going_nowhere = True
+            while type(ast[next_pos]) == p.JumpOp and \
+                not visited[next_pos] and \
+                not jump_going_nowhere:
+                visited[next_pos] = True
+                _label = ast[next_pos].label_name
+                try:
+                    next_pos = labels_positions[_label]
+                except KeyError:
+                    jump_going_nowhere = True
 
             if jump_going_nowhere:
                 pass

--- a/hrmcompiler/conversion.py
+++ b/hrmcompiler/conversion.py
@@ -173,12 +173,11 @@ def compress_jumps(ast):
                 jump_going_nowhere = True
 
             if jump_going_nowhere:
-                # even though the **conditional** jump redirects to a label
+                # even though a jump, either conditional or unconditional, redirects to a label
                 # that is _not_ associated to any instruction, removing conditional
                 # jumps alters the logic of the program
-                if type(ast_item) == p.JumpCondOp:
-                    compressed_ast.append(ast_item)
-                    continue
+                compressed_ast.append(ast_item)
+                continue
 
             if not jump_going_nowhere:
                 while type(ast[next_pos]) == p.JumpOp and \

--- a/hrmcompiler/conversion.py
+++ b/hrmcompiler/conversion.py
@@ -127,13 +127,8 @@ def remove_unreachable_code(ast):
                             next_pointers[prev_ic] = (_next_pos, -1)
                         else:
                             next_pointers[ic] = (_next_pos, -1)
-                        #if assoc[_next_pos] != None:
-                        #    assoc[_next_pos].append(instr.label_name)
-                        #else:
-                        #    assoc[_next_pos] = [instr.label_name]
                         ast[ic] = p.JumpOp("_hrm_unreachable")
                         hrm_unreachable_used = True
-                        # TODO(winter): create test case for ic=INSTRUCTIONS_NUM, jcond_stack not empty
                         ic = INSTRUCTIONS_NUM
                 else:
                     if type(instr) == p.JumpCondOp:

--- a/hrmcompiler/conversion.py
+++ b/hrmcompiler/conversion.py
@@ -187,9 +187,7 @@ def compress_jumps(ast):
                 except KeyError:
                     jump_going_nowhere = True
 
-            if jump_going_nowhere:
-                pass
-            elif type(ast_item) == p.JumpOp:
+            if type(ast_item) == p.JumpOp:
                 compressed_ast.append(p.JumpOp(_label))
             else:
                 compressed_ast.append(p.JumpCondOp(_label, ast_item.condition))

--- a/tests/test_jump_compression.py
+++ b/tests/test_jump_compression.py
@@ -164,6 +164,7 @@ def test_jcond_lone_label():
         parser.AssignOp(src="inbox", dst="emp"),
         parser.JumpCondOp("start", "ez"),
             parser.JumpOp("start"),
+            parser.JumpOp("_generated_endif"),
         parser.LabelStmt("if"),
             parser.JumpOp("start"),
         parser.LabelStmt("_generated_endif")
@@ -226,3 +227,23 @@ def test_dont_optimize_conditional_jumps():
     ]
     ast = compress_jumps(start_ast)
     assert parser.JumpCondOp(label_name="_hrm_1", condition="jez") in ast
+
+def test_dont_optimize_jumps_with_missing_label():
+    start_ast = [
+            parser.LabelStmt("start"),
+            parser.AssignOp(src="inbox", dst="emp"),
+            parser.JumpOp(label_name="misspelled_start"),
+            parser.OutboxOp(),
+            parser.JumpOp(label_name="start"),
+            parser.LabelStmt("misspelled_start"),
+    ]
+    expected_ast = [
+            parser.LabelStmt("start"),
+            parser.AssignOp(src="inbox", dst="emp"),
+            parser.JumpOp(label_name="misspelled_start"),
+            parser.OutboxOp(),
+            parser.JumpOp(label_name="start"),
+            parser.LabelStmt("misspelled_start"),
+    ]
+    ast = compress_jumps(start_ast)
+    assert ast == expected_ast

--- a/tests/test_jump_compression.py
+++ b/tests/test_jump_compression.py
@@ -247,3 +247,31 @@ def test_dont_optimize_jumps_with_missing_label():
     ]
     ast = compress_jumps(start_ast)
     assert ast == expected_ast
+
+def test_dont_optimize_jumps_with_missing_label_in_chain():
+    start_ast = [
+            parser.LabelStmt("start"),
+            parser.AssignOp(src="inbox", dst="emp"),
+            parser.JumpOp(label_name="a"),
+            parser.OutboxOp(),
+            parser.JumpOp(label_name="start"),
+            parser.LabelStmt("a"),
+            parser.JumpOp(label_name="b"),
+            parser.LabelStmt("b"),
+            parser.JumpOp(label_name="misspelled_start"),
+            parser.LabelStmt("misspelled_start"),
+    ]
+    expected_ast = [
+            parser.LabelStmt("start"),
+            parser.AssignOp(src="inbox", dst="emp"),
+            parser.JumpOp(label_name="misspelled_start"),
+            parser.OutboxOp(),
+            parser.JumpOp(label_name="start"),
+            parser.LabelStmt("a"),
+            parser.JumpOp(label_name="misspelled_start"),
+            parser.LabelStmt("b"),
+            parser.JumpOp(label_name="misspelled_start"),
+            parser.LabelStmt("misspelled_start"),
+    ]
+    ast = compress_jumps(start_ast)
+    assert ast == expected_ast

--- a/tests/test_remove_unreachable_code.py
+++ b/tests/test_remove_unreachable_code.py
@@ -193,11 +193,10 @@ def test_unreachable_jumps():
     ]
     expected_ast = [
         parser.AssignOp(src="inbox", dst="emp"),
-        # the indented part is needed in the test
-        # it would be optimized because of the previous
-        # 'jump compression' optimization
-        # but every jump here is reachable if the
-        # code is passed as in the test.
+        # the indented part is needed in this test.
+        # when run from `hrmc`, it'd be optimized
+        # because of the previous 'jump compression' optimization,
+        # but we are not using an optimized ast here.
              parser.JumpOp("label_a"),
              parser.LabelStmt("label_a"),
              parser.JumpOp("label_b"),

--- a/tests/test_remove_unreachable_code.py
+++ b/tests/test_remove_unreachable_code.py
@@ -157,7 +157,8 @@ def test_unreachable_condjumps():
     expected_ast = [
         parser.AssignOp(src="inbox", dst="emp"),
         parser.JumpCondOp("_hrm_unreachable", "jez"),
-        parser.OutboxOp()
+        parser.OutboxOp(),
+        parser.LabelStmt("_hrm_unreachable")
     ]
     ast = remove_unreachable_code(start_ast)
     assert ast == expected_ast
@@ -175,3 +176,36 @@ def test_no_operation_ignored_in_nonlooping_code():
     ast = remove_unreachable_code(start_ast)
     assert parser.IncrOp("b_field") in start_ast
     assert parser.IncrOp("b_field") in ast
+
+def test_unreachable_jumps():
+    start_ast = [
+        parser.LabelStmt("start"),
+        parser.AssignOp(src="inbox", dst="emp"),
+        parser.JumpOp("label_a"),
+        parser.LabelStmt("label_a"),
+        parser.JumpOp("label_b"),
+        parser.LabelStmt("label_b"),
+        parser.JumpOp("label_c"),
+        parser.LabelStmt("label_c"),
+        parser.JumpOp("label_z"),
+        parser.JumpOp("start"),
+        parser.LabelStmt("label_z")
+    ]
+    expected_ast = [
+        parser.AssignOp(src="inbox", dst="emp"),
+        # the indented part is needed in the test
+        # it would be optimized because of the previous
+        # 'jump compression' optimization
+        # but every jump here is reachable if the
+        # code is passed as in the test.
+             parser.JumpOp("label_a"),
+             parser.LabelStmt("label_a"),
+             parser.JumpOp("label_b"),
+             parser.LabelStmt("label_b"),
+             parser.JumpOp("label_c"),
+             parser.LabelStmt("label_c"),
+        parser.JumpOp("_hrm_unreachable"),
+        parser.LabelStmt("_hrm_unreachable")
+    ]
+    ast = remove_unreachable_code(start_ast)
+    assert ast == expected_ast

--- a/tests/test_remove_unreachable_code.py
+++ b/tests/test_remove_unreachable_code.py
@@ -208,3 +208,27 @@ def test_unreachable_jumps():
     ]
     ast = remove_unreachable_code(start_ast)
     assert ast == expected_ast
+
+def test_unreachable_jump_to_lone_label_in_jcond_false_path():
+    start_ast = [
+        parser.LabelStmt("start"),
+        parser.AssignOp(src="inbox", dst="emp"),
+        parser.JumpCondOp(condition="ez", label_name="isZero"),
+        parser.JumpOp("loneLabel"),
+        parser.LabelStmt("isZero"),
+        parser.OutboxOp(),
+        parser.JumpOp("start"),
+        parser.LabelStmt("loneLabel")
+    ]
+    expected_ast = [
+        parser.LabelStmt("start"),
+        parser.AssignOp(src="inbox", dst="emp"),
+        parser.JumpCondOp(condition="ez", label_name="isZero"),
+        parser.JumpOp("_hrm_unreachable"),
+        parser.LabelStmt("isZero"),
+        parser.OutboxOp(),
+        parser.JumpOp("start"),
+        parser.LabelStmt("_hrm_unreachable")
+    ]
+    ast = remove_unreachable_code(start_ast)
+    assert ast == expected_ast


### PR DESCRIPTION
this MR fixes a huge bug in the _compress-jumps_ optimization that would lead to remove `jmp` instructions if they point to labels that tag no instructions (see tests and examples).

In this MR, there is also a small change in order to be able to run programs with `_hrm_unreachable` on hrm-interpreter. bonus refactoring and testing added!