### PR TITLE
Fix jmp then label

### DIFF
--- a/examples/jmpthenlabel.hrm
+++ b/examples/jmpthenlabel.hrm
@@ -1,0 +1,12 @@
+start:
+inbox
+if neg then
+    jmp start
+endif
+if ez then
+    jmp start
+else
+    0 = emp
+endif
+jmp start
+

--- a/hrmcompiler/__init__.py
+++ b/hrmcompiler/__init__.py
@@ -10,5 +10,8 @@ def main():
     parser.add_argument("--no-unreachable",
             action="store_true", default=False,
             help="disable unreachable code optimization")
+    parser.add_argument("--no-jmp-then-label",
+            action="store_true", default=False,
+            help="disable an optimization to remove jumps followed by the label referenced from the jump")
 
     _main(parser.parse_args())

--- a/hrmcompiler/conversion.py
+++ b/hrmcompiler/conversion.py
@@ -1,6 +1,7 @@
 from hrmcompiler.parser import IfOp
 import hrmcompiler.parser as p
 from pprint import pprint
+import itertools as it
 
 def convert_ifnz_to_ifez(ast):
     new_ast = []
@@ -209,3 +210,21 @@ def compress_jumps(ast):
             compressed_ast.append(ast_item)
 
     return compressed_ast
+
+def fix_jmp_then_label(ast):
+    new_ast = []
+
+    skip_label = False
+    for (a_instr, b_instr) in it.zip_longest(ast, ast[1:]):
+        if type(a_instr) == p.JumpOp and type(b_instr) == p.LabelStmt:
+            if a_instr.label_name != b_instr.label_name:
+                new_ast.append(a_instr)
+                skip_label = False
+            else:
+                skip_label = True
+        elif skip_label:
+            skip_label = False
+        else:
+            new_ast.append(a_instr)
+
+    return new_ast

--- a/hrmcompiler/main.py
+++ b/hrmcompiler/main.py
@@ -22,6 +22,8 @@ def main(args):
             result_ast = conversion.compress_jumps(result_ast)
         if not args.no_unreachable:
             result_ast = conversion.remove_unreachable_code(result_ast)
+        if not args.no_jmp_then_label:
+            result_ast = conversion.fix_jmp_then_label(result_ast)
 
         assembler = a.Assembler()
         assembler.convert(result_ast)

--- a/tests/test_conversionphase_jumpthenlabel.py
+++ b/tests/test_conversionphase_jumpthenlabel.py
@@ -1,0 +1,38 @@
+import pytest
+from hrmcompiler import parser as p
+from hrmcompiler import conversion
+
+def test_convert_jmpthenlabel_check():
+    code = [
+        p.LabelStmt("alreadySorted"),
+        p.AssignOp(src="inbox", dst="emp"),
+        p.IfOp("neg", [p.JumpOp("alreadySorted")], []),
+        p.IfOp("ez", [p.JumpOp("alreadySorted")], [p.AssignOp(src="0", dst="emp")])
+    ]
+    expected_ast = [
+        p.LabelStmt("alreadySorted"),
+        p.AssignOp(src="inbox", dst="emp"),
+        p.JumpCondOp(condition="jneg", label_name="alreadySorted"),
+            # pass
+        #    p.JumpOp("_hrm_endif_1"),
+        #p.LabelStmt("_hrm_endif_1"),
+        p.JumpCondOp(condition="jez", label_name="alreadySorted"),
+            p.AssignOp(src="0", dst="emp")
+        #    p.JumpOp("_hrm_unreachable"),
+        #p.LabelStmt("_hrm_unreachable")
+    ]
+    result_ast = conversion.convert_ifnz_to_ifez(code)
+    result_ast = conversion.convert_iftojump(result_ast)
+    result_ast = conversion.compress_jumps(result_ast)
+    result_ast = conversion.remove_unreachable_code(result_ast)
+
+    ast = conversion.fix_jmp_then_label(result_ast)
+
+    assert ast == expected_ast
+
+def test_convert_jmpthenlabel_not_remove_everything():
+    code = [p.JumpOp("b"), p.LabelStmt("a")]
+    code_ = [p.JumpOp("b"), p.LabelStmt("a"), p.OutboxOp()]
+
+    assert code == conversion.fix_jmp_then_label(code)
+    assert code_ == conversion.fix_jmp_then_label(code_)


### PR DESCRIPTION
Introduce a new pass to remove unconditional jumps if they're followed by the label they are going to jump to.

```
jmp test
test:
inbox
```

becomes

```
# note that "jmp test" disappeared
test:
inbox
```